### PR TITLE
Update copyright to 2016

### DIFF
--- a/src/data/graphml1.xml
+++ b/src/data/graphml1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2014 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/src/main/assembly/docs-assembly.xml
+++ b/src/main/assembly/docs-assembly.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2002-2014 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/src/main/assembly/server-plugin.xml
+++ b/src/main/assembly/server-plugin.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2002-2014 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/src/main/java/org/neo4j/server/plugin/sparql/SPARQLPlugin.java
+++ b/src/main/java/org/neo4j/server/plugin/sparql/SPARQLPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/main/java/org/neo4j/server/rest/repr/SparqlMapRepresentation.java
+++ b/src/main/java/org/neo4j/server/rest/repr/SparqlMapRepresentation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/main/java/org/neo4j/server/rest/repr/SparqlObjectToRepresentationConverter.java
+++ b/src/main/java/org/neo4j/server/rest/repr/SparqlObjectToRepresentationConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/test/java/org/neo4j/server/plugin/sparql/BerlinDatasetTest.java
+++ b/src/test/java/org/neo4j/server/plugin/sparql/BerlinDatasetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/test/java/org/neo4j/server/plugin/sparql/SPARQLPluginFunctionalTest.java
+++ b/src/test/java/org/neo4j/server/plugin/sparql/SPARQLPluginFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/test/java/org/neo4j/server/plugin/sparql/SPARQLPluginTest.java
+++ b/src/test/java/org/neo4j/server/plugin/sparql/SPARQLPluginTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2002-2014 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.


### PR DESCRIPTION
Just changed some header license information from

`Copyright (c) 2002-2014 "Neo Technology,"`

to

`Copyright (c) 2002-2016 "Neo Technology,"`

Fixes maven build and install errors.